### PR TITLE
Remove slashes from filenames to avoid exceptions

### DIFF
--- a/paprika_recipes/commands/extract_archive.py
+++ b/paprika_recipes/commands/extract_archive.py
@@ -24,9 +24,10 @@ class Command(BaseCommand):
             self.options.export_path.mkdir(parents=True, exist_ok=True)
 
             for recipe in archive:
+                recipe_path = recipe.name.replace('/', ' ')
                 with open(
                     self.options.export_path
-                    / Path(f"{recipe.name}.paprikarecipe.yaml"),
+                    / Path(f"{recipe_path}.paprikarecipe.yaml"),
                     "w",
                 ) as outf:
                     dump_recipe_yaml(recipe, outf)


### PR DESCRIPTION
When a recipe includes a slash in the file name, something like "Almond butter rice cakes/toasts", `extract-archive` will throw an exception because it interprets the slash as a folder when it tries to create the yaml file. Normally I'd want to slugify or escape the file name to be a bit safer, but since it seems like you're going for more of a human readable text file name thing, I opted to simply replace the slashes with spaces.

*Disclaimer: I'm not super familiar with Python. I don't know if this is an accurate solution, and haven't tested it.*

